### PR TITLE
feat: add Avellaneda-Stoikov backtester with microprice enhancement

### DIFF
--- a/config/as_microprice.conf
+++ b/config/as_microprice.conf
@@ -1,0 +1,16 @@
+# Avellaneda-Stoikov 2008 - reference price: Stoikov (2018) microprice
+ref_price_mode = microprice
+
+gamma = 1e-8
+k = 20000000
+vol_halflife_ticks = 2000
+inv_cap = 50000
+base_qty = 1000
+session_horizon_ticks = 1000000
+latency_ns = 100000
+
+data.lob    = lob.csv
+data.trades = trades.csv
+
+fees.maker = -0.00005
+fees.taker =  0.0007

--- a/config/as_mid.conf
+++ b/config/as_mid.conf
@@ -1,0 +1,16 @@
+# Avellaneda-Stoikov 2008 - reference price: arithmetic mid
+ref_price_mode = mid
+
+gamma = 1e-8
+k = 20000000
+vol_halflife_ticks = 2000
+inv_cap = 50000
+base_qty = 1000
+session_horizon_ticks = 1000000
+latency_ns = 100000
+
+data.lob    = lob.csv
+data.trades = trades.csv
+
+fees.maker = -0.00005
+fees.taker =  0.0007

--- a/scripts/plot_results.py
+++ b/scripts/plot_results.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+import sys
+import os
+
+try:
+    import polars as pl
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+except ImportError as e:
+    print(f"Missing dependency: {e}\npip install polars matplotlib")
+    sys.exit(1)
+
+RESULTS = "results"
+VARIANTS = ["mid", "microprice"]
+COLORS = {"mid": "#1f77b4", "microprice": "#ff7f0e"}
+
+
+def load_equity(variant: str) -> pl.DataFrame:
+    path = os.path.join(RESULTS, variant, "equity.csv")
+    df = pl.read_csv(path)
+    df = df.with_columns(
+        ((pl.col("ts") - pl.col("ts").first()) / 1e9 / 3600).alias("hours")
+    )
+    n = len(df)
+    step = max(1, n // 5000)
+    return df[::step]
+
+
+def load_summary() -> pl.DataFrame:
+    rows = []
+    for v in VARIANTS:
+        path = os.path.join(RESULTS, v, "summary.txt")
+        if not os.path.exists(path):
+            continue
+        d: dict = {"variant": v}
+        with open(path) as f:
+            in_metrics = False
+            for line in f:
+                line = line.strip()
+                if line == "metric,value":
+                    in_metrics = True
+                    continue
+                if in_metrics and "," in line:
+                    key, val = line.split(",", 1)
+                    try:
+                        d[key] = float(val)
+                    except ValueError:
+                        d[key] = val
+        rows.append(d)
+    if not rows:
+        return pl.DataFrame()
+    keys = list({k for r in rows for k in r})
+    return pl.DataFrame({k: [r.get(k) for r in rows] for k in keys})
+
+
+def equity_plot(dfs: dict) -> None:
+    fig, axes = plt.subplots(2, 1, figsize=(12, 8), sharex=True)
+
+    for v, df in dfs.items():
+        axes[0].plot(df["hours"], df["equity"], lw=0.6, color=COLORS[v], label=v)
+        axes[1].plot(df["hours"], df["inventory"], lw=0.4, color=COLORS[v], label=v, alpha=0.8)
+
+    axes[0].set_ylabel("Equity (mark-to-market)")
+    axes[0].axhline(0, color="black", lw=0.5, ls="--")
+    axes[0].legend()
+    axes[0].grid(True, alpha=0.3)
+
+    axes[1].set_ylabel("Net inventory (units)")
+    axes[1].set_xlabel("Elapsed time (hours)")
+    axes[1].axhline(0, color="black", lw=0.5, ls="--")
+    axes[1].legend()
+    axes[1].grid(True, alpha=0.3)
+
+    fig.suptitle("Avellaneda-Stoikov Market Making - 6-Day Backtest")
+    fig.tight_layout()
+    out = os.path.join(RESULTS, "equity_compare.png")
+    fig.savefig(out, dpi=150)
+    plt.close(fig)
+    print(f"Saved {out}")
+
+
+def microstructure_plot(dfs: dict) -> None:
+    fig, axes = plt.subplots(2, 1, figsize=(12, 6), sharex=True)
+
+    for v, df in dfs.items():
+        sub = df.filter(pl.col("hours") <= 6)
+        axes[0].plot(sub["hours"], sub["equity"], lw=0.8, color=COLORS[v], label=v)
+        axes[1].plot(sub["hours"], sub["inventory"], lw=0.6, color=COLORS[v], label=v, alpha=0.9)
+
+    axes[0].set_ylabel("Equity")
+    axes[0].axhline(0, color="black", lw=0.5, ls="--")
+    axes[0].legend()
+    axes[0].grid(True, alpha=0.3)
+
+    axes[1].set_ylabel("Net inventory")
+    axes[1].set_xlabel("Elapsed time (hours)")
+    axes[1].axhline(0, color="black", lw=0.5, ls="--")
+    axes[1].legend()
+    axes[1].grid(True, alpha=0.3)
+
+    fig.suptitle("First 6 Hours - Equity and Inventory Detail")
+    fig.tight_layout()
+    out = os.path.join(RESULTS, "microstructure_detail.png")
+    fig.savefig(out, dpi=150)
+    plt.close(fig)
+    print(f"Saved {out}")
+
+
+def summary_table(summary: pl.DataFrame) -> None:
+    if summary.is_empty():
+        print("No summary data found (run experiments first)")
+        return
+    out = os.path.join(RESULTS, "summary_table.csv")
+    summary.write_csv(out)
+    print(f"Saved {out}")
+    print(summary)
+
+
+def main() -> None:
+    os.chdir(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+    dfs = {}
+    for v in VARIANTS:
+        path = os.path.join(RESULTS, v, "equity.csv")
+        if os.path.exists(path):
+            dfs[v] = load_equity(v)
+        else:
+            print(f"Missing {path}, skipping {v}")
+
+    if dfs:
+        equity_plot(dfs)
+        microstructure_plot(dfs)
+
+    summary = load_summary()
+    summary_table(summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_experiments.sh
+++ b/scripts/run_experiments.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -e
+REPO="$(dirname "$0")/.."
+BIN="$REPO/build/bin/hft-market-making"
+
+echo "=== Building ==="
+cmake -S "$REPO" -B "$REPO/build" -DCMAKE_BUILD_TYPE=Release -DDISABLE_PRINT=1
+cmake --build "$REPO/build" -j
+
+cd "$REPO"
+
+for mode in mid microprice; do
+    echo ""
+    echo "=== Running A-S ($mode) ==="
+    outdir="results/$mode"
+    mkdir -p "$outdir"
+    "$BIN" "config/as_${mode}.conf" 2>&1 | tee "$outdir/summary.txt"
+    for f in executions.csv equity.csv stoikov_mm.log; do
+        [ -f "$f" ] && mv "$f" "$outdir/"
+    done
+done
+
+echo ""
+echo "=== Generating plots ==="
+python3 scripts/plot_results.py
+
+echo ""
+echo "Done. Results in results/"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,5 @@
 add_subdirectory(common)
+add_subdirectory(engine)
+add_subdirectory(io)
+add_subdirectory(strategy)
 add_subdirectory(main)

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(TARGET hft-market-making-engine)
+file(GLOB SRC CONFIGURE_DEPENDS *.cpp)
+add_library(${TARGET} STATIC ${SRC})
+target_link_libraries(${TARGET} PUBLIC hft-market-making-common)

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -1,0 +1,255 @@
+#include "engine/Engine.hpp"
+#include <limits>
+
+namespace cmf
+{
+
+BacktestEngine::BacktestEngine(std::unique_ptr<LatencyModel> latency,
+                               std::unique_ptr<Strategy> strategy,
+                               Fees fees)
+    : latency_(std::move(latency)), strat_(std::move(strategy)), fees_(fees)
+{
+    ctx_.send_order = [this](const Order& o) { return place_order(o); };
+    ctx_.cancel_order = [this](ClOrdId id) { cancel(id); };
+}
+
+void BacktestEngine::schedule(NanoTime when, std::function<void()> fn)
+{
+    q_.push(Event{when, seqCounter_++, std::move(fn)});
+}
+
+ClOrdId BacktestEngine::place_order(Order o)
+{
+    if (o.id == 0)
+        o.id = nextOrderId_++;
+    const NanoTime d = latency_ ? latency_->sample_delay(o.ts) : 0;
+    const NanoTime execTs = o.ts + d;
+    liveOrders_[o.id] = o;
+    ++totalSent_;
+    Logger::log("ORDER_NEW id=" + std::to_string(o.id) +
+                " ts=" + std::to_string(o.ts) +
+                " side=" + (o.side == Side::Buy ? "buy" : "sell") +
+                " px=" + std::to_string(o.price) +
+                " qty=" + std::to_string(o.amount));
+    schedule(execTs, [this, o]() {
+        if (!liveOrders_.count(o.id))
+            return;
+        ExecReport rep{};
+        bool isMaker = false;
+        if (o.type == OrderType::Market)
+        {
+            rep = OrderBook::execute_market(o, lastBook_);
+            isMaker = false;
+        }
+        else if (OrderBook::limit_crossed(o, lastBook_))
+        {
+            rep = OrderBook::aggressor_fill(o, lastBook_);
+            isMaker = false;
+        }
+        else
+        {
+            return; // resting
+        }
+        if (rep.filled > 0.0)
+        {
+            apply_fill(o, rep, isMaker);
+            liveOrders_.erase(o.id);
+        }
+    });
+    return o.id;
+}
+
+void BacktestEngine::run()
+{
+    L2Snapshot s{};
+    TradeEvent t{};
+    bool hasL2 = l2_ && l2_->next(s);
+    bool hasT = trades_ && trades_->next(t);
+
+    while (hasL2 || hasT || !q_.empty())
+    {
+        NanoTime nextDataTs = std::numeric_limits<NanoTime>::max();
+        enum WhichNext
+        {
+            NONE,
+            L2,
+            TRADE
+        } which = NONE;
+        if (hasL2 && s.ts < nextDataTs)
+        {
+            nextDataTs = s.ts;
+            which = L2;
+        }
+        if (hasT && t.ts < nextDataTs)
+        {
+            nextDataTs = t.ts;
+            which = TRADE;
+        }
+        if (!q_.empty() && q_.top().ts <= nextDataTs)
+        {
+            auto ev = q_.top();
+            q_.pop();
+            ev.fn();
+            continue;
+        }
+        if (which == L2)
+        {
+            lastBook_ = s;
+            if (!s.asks.empty() && !s.bids.empty())
+                lastMid_ = 0.5 * (s.asks.front().price + s.bids.front().price);
+            process_live_orders_on_l2();
+            strat_->on_l2(s, ctx_);
+            if (lastMid_ != 0.0)
+                recompute_equity(s.ts, lastMid_);
+            hasL2 = l2_->next(s);
+        }
+        else if (which == TRADE)
+        {
+            process_live_orders_on_trade(t);
+            strat_->on_trade(t, ctx_);
+            hasT = trades_->next(t);
+        }
+        else
+        {
+            if (!q_.empty())
+            {
+                auto ev = q_.top();
+                q_.pop();
+                ev.fn();
+            }
+            else
+            {
+                break;
+            }
+        }
+    }
+}
+
+void BacktestEngine::cancel(ClOrdId id)
+{
+    if (liveOrders_.erase(id))
+        Logger::log("ORDER_CANCEL id=" + std::to_string(id));
+}
+
+void BacktestEngine::apply_fill(const Order& o, const ExecReport& rep, bool isMaker)
+{
+    const double notional = rep.avgPrice * rep.filled;
+    const double feeRate = isMaker ? fees_.maker : fees_.taker;
+    const double fee = notional * feeRate;
+
+    const double eqBefore = (lastMid_ != 0.0) ? pf_.cash + pf_.position * lastMid_ : 0.0;
+
+    execs_.push_back(TradeRecord{rep.ts, rep.filled, rep.avgPrice, o.side, fee});
+    ++totalFilled_;
+
+    const double signedQty = (o.side == Side::Buy ? 1.0 : -1.0) * rep.filled;
+    pf_.cash -= signedQty * rep.avgPrice;
+    pf_.cash -= fee;
+    pf_.position += signedQty;
+
+    if (lastMid_ != 0.0)
+    {
+        const double eq = pf_.cash + pf_.position * lastMid_;
+        inventory_.push_back(pf_.position);
+        equity_.push_back(eq);
+        equityTs_.push_back(rep.ts);
+        const double ret = (lastEquity_ != 0.0) ? (eq - lastEquity_) / std::abs(lastEquity_) : 0.0;
+        unrealRets_.push_back(ret);
+        lastEquity_ = eq;
+        (void)eqBefore;
+    }
+
+    Logger::log("ORDER_FILL id=" + std::to_string(o.id) +
+                " ts=" + std::to_string(rep.ts) +
+                " side=" + (o.side == Side::Buy ? "buy" : "sell") +
+                " px=" + std::to_string(rep.avgPrice) +
+                " qty=" + std::to_string(rep.filled) +
+                (isMaker ? " maker" : " taker"));
+
+    strat_->on_fill(rep, o.side, isMaker, ctx_);
+}
+
+void BacktestEngine::recompute_equity(NanoTime ts, double midPx)
+{
+    const double eq = pf_.cash + pf_.position * midPx;
+    if (equity_.empty())
+    {
+        equity_.push_back(eq);
+        equityTs_.push_back(ts);
+        inventory_.push_back(pf_.position);
+        lastEquity_ = eq;
+        unrealRets_.push_back(0.0);
+        lastTs_ = ts;
+    }
+    else
+    {
+        if (lastTs_ >= 0 && ts > lastTs_)
+        {
+            sumDtNs_ += static_cast<long double>(ts - lastTs_);
+            ++dtSamples_;
+            lastTs_ = ts;
+        }
+        const double ret = (lastEquity_ != 0.0) ? (eq - lastEquity_) / std::abs(lastEquity_) : 0.0;
+        unrealRets_.push_back(ret);
+        equity_.push_back(eq);
+        equityTs_.push_back(ts);
+        inventory_.push_back(pf_.position);
+        lastEquity_ = eq;
+    }
+}
+
+double BacktestEngine::estimated_steps_per_year() const
+{
+    if (dtSamples_ == 0 || sumDtNs_ <= 0.0L)
+        return 31'536'000.0;
+    const long double avgNs = sumDtNs_ / static_cast<long double>(dtSamples_);
+    return static_cast<double>(31'536'000.0L * 1'000'000'000.0L / avgNs);
+}
+
+void BacktestEngine::process_live_orders_on_l2()
+{
+    if (liveOrders_.empty())
+        return;
+    std::vector<ClOrdId> toErase;
+    for (const auto& [id, o] : liveOrders_)
+    {
+        if (o.type == OrderType::Limit && OrderBook::limit_crossed(o, lastBook_))
+        {
+            const auto& contra = (o.side == Side::Buy) ? lastBook_.asks : lastBook_.bids;
+            const double contraQty = contra.empty() ? o.amount : contra.front().amount;
+            const ExecReport rep = OrderBook::passive_fill(o, contraQty, lastBook_.ts);
+            apply_fill(o, rep, true);
+            toErase.push_back(id);
+        }
+    }
+    for (ClOrdId id : toErase)
+        liveOrders_.erase(id);
+}
+
+void BacktestEngine::process_live_orders_on_trade(const TradeEvent& t)
+{
+    if (liveOrders_.empty())
+        return;
+    std::vector<ClOrdId> toErase;
+    for (const auto& [id, o] : liveOrders_)
+    {
+        if (o.type != OrderType::Limit)
+            continue;
+        if (o.side == Side::Buy && t.price <= o.price)
+        {
+            const ExecReport rep = OrderBook::passive_fill(o, t.amount, t.ts);
+            apply_fill(o, rep, true);
+            toErase.push_back(id);
+        }
+        else if (o.side == Side::Sell && t.price >= o.price)
+        {
+            const ExecReport rep = OrderBook::passive_fill(o, t.amount, t.ts);
+            apply_fill(o, rep, true);
+            toErase.push_back(id);
+        }
+    }
+    for (ClOrdId id : toErase)
+        liveOrders_.erase(id);
+}
+
+} // namespace cmf

--- a/src/engine/Engine.hpp
+++ b/src/engine/Engine.hpp
@@ -1,0 +1,119 @@
+#pragma once
+
+#include "engine/LatencyModel.hpp"
+#include "engine/Logger.hpp"
+#include "engine/Metrics.hpp"
+#include "engine/OrderBook.hpp"
+#include "engine/Types.hpp"
+#include <functional>
+#include <memory>
+#include <queue>
+#include <unordered_map>
+#include <vector>
+
+namespace cmf
+{
+
+// Minimal reader interfaces so engine has no dependency on io module.
+struct IL2Reader
+{
+    virtual ~IL2Reader() = default;
+    virtual bool next(L2Snapshot& out) = 0;
+};
+
+struct ITradesReader
+{
+    virtual ~ITradesReader() = default;
+    virtual bool next(TradeEvent& out) = 0;
+};
+
+struct StrategyContext;
+
+struct Strategy
+{
+    virtual ~Strategy() = default;
+    virtual void on_l2(const L2Snapshot& l2, StrategyContext& ctx) = 0;
+    virtual void on_trade(const TradeEvent& t, StrategyContext& ctx) = 0;
+    virtual void on_fill(const ExecReport&, Side, bool /*isMaker*/, StrategyContext&) {}
+};
+
+struct StrategyContext
+{
+    std::function<ClOrdId(const Order&)> send_order;
+    std::function<void(ClOrdId)> cancel_order;
+};
+
+struct Event
+{
+    NanoTime ts{0};
+    std::uint64_t seq{0};
+    std::function<void()> fn;
+
+    bool operator>(const Event& o) const
+    {
+        return ts > o.ts || (ts == o.ts && seq > o.seq);
+    }
+};
+
+class BacktestEngine
+{
+public:
+    BacktestEngine(std::unique_ptr<LatencyModel> latency,
+                   std::unique_ptr<Strategy> strategy,
+                   Fees fees = {});
+
+    void set_l2_reader(std::unique_ptr<IL2Reader> r) { l2_ = std::move(r); }
+    void set_trades_reader(std::unique_ptr<ITradesReader> r) { trades_ = std::move(r); }
+
+    void run();
+
+    const std::vector<TradeRecord>& executions() const { return execs_; }
+    const Portfolio& portfolio() const { return pf_; }
+    const std::vector<double>& equity_series() const { return equity_; }
+    const std::vector<double>& unrealized_returns_series() const { return unrealRets_; }
+    const std::vector<NanoTime>& equity_ts_series() const { return equityTs_; }
+    const std::vector<double>& inventory_series() const { return inventory_; }
+    std::uint64_t sent_count() const { return totalSent_; }
+    std::uint64_t filled_count() const { return totalFilled_; }
+    double estimated_steps_per_year() const;
+
+private:
+    void schedule(NanoTime when, std::function<void()> fn);
+    ClOrdId place_order(Order o);
+    void cancel(ClOrdId id);
+    void apply_fill(const Order& o, const ExecReport& rep, bool isMaker);
+    void recompute_equity(NanoTime ts, double midPx);
+    void process_live_orders_on_l2();
+    void process_live_orders_on_trade(const TradeEvent& t);
+
+    std::unique_ptr<LatencyModel> latency_;
+    std::unique_ptr<Strategy> strat_;
+    std::unique_ptr<IL2Reader> l2_;
+    std::unique_ptr<ITradesReader> trades_;
+    Fees fees_;
+
+    L2Snapshot lastBook_{};
+    std::priority_queue<Event, std::vector<Event>, std::greater<Event>> q_;
+    StrategyContext ctx_;
+
+    std::vector<TradeRecord> execs_;
+    ClOrdId nextOrderId_{1};
+    Portfolio pf_{};
+    std::unordered_map<ClOrdId, Order> liveOrders_;
+
+    std::vector<double> equity_;
+    std::vector<double> unrealRets_;
+    std::vector<NanoTime> equityTs_;
+    std::vector<double> inventory_;
+
+    double lastEquity_{0.0};
+    double lastMid_{0.0};
+    NanoTime lastTs_{-1};
+    long double sumDtNs_{0.0L};
+    std::size_t dtSamples_{0};
+    std::uint64_t seqCounter_{0};
+    std::uint64_t totalSent_{0};
+    std::uint64_t totalFilled_{0};
+};
+
+} // namespace cmf

--- a/src/engine/LatencyModel.hpp
+++ b/src/engine/LatencyModel.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "engine/Types.hpp"
+#include <random>
+
+namespace cmf
+{
+
+struct LatencyModel
+{
+    virtual ~LatencyModel() = default;
+    virtual NanoTime sample_delay(NanoTime now) = 0;
+};
+
+struct ConstLatency : LatencyModel
+{
+    NanoTime delay{0};
+    explicit ConstLatency(NanoTime d) : delay(d) {}
+    NanoTime sample_delay(NanoTime) override { return delay; }
+};
+
+struct LognormalLatency : LatencyModel
+{
+    std::mt19937_64 rng;
+    std::lognormal_distribution<double> dist;
+    NanoTime minClamp{0};
+
+    LognormalLatency(std::uint64_t seed, double m, double s, NanoTime minClampNs = 0)
+        : rng(seed), dist(m, s), minClamp(minClampNs)
+    {
+    }
+
+    NanoTime sample_delay(NanoTime) override
+    {
+        const auto d = static_cast<NanoTime>(dist(rng));
+        return d < minClamp ? minClamp : d;
+    }
+};
+
+} // namespace cmf

--- a/src/engine/Logger.hpp
+++ b/src/engine/Logger.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <fstream>
+#include <mutex>
+#include <string>
+
+namespace cmf
+{
+
+class Logger
+{
+public:
+    static void set_path(const std::string& p)
+    {
+        std::lock_guard<std::mutex> g(mu());
+        if (ofs().is_open())
+            ofs().close();
+        ofs().open(p, std::ios::out | std::ios::app);
+    }
+
+    static void log(const std::string& line)
+    {
+        std::lock_guard<std::mutex> g(mu());
+        if (!ofs().is_open())
+            return;
+        ofs() << line << '\n';
+        ofs().flush();
+    }
+
+private:
+    static std::ofstream& ofs()
+    {
+        static std::ofstream f;
+        return f;
+    }
+    static std::mutex& mu()
+    {
+        static std::mutex m;
+        return m;
+    }
+};
+
+} // namespace cmf

--- a/src/engine/Metrics.cpp
+++ b/src/engine/Metrics.cpp
@@ -1,0 +1,109 @@
+#include "engine/Metrics.hpp"
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <numeric>
+
+namespace cmf
+{
+
+double RealizedPnL::calculate() const
+{
+    double pnl = 0.0;
+    for (const auto& e : trades)
+        pnl += (e.side == Side::Sell ? 1.0 : -1.0) * e.qty * e.price - e.fee;
+    return pnl;
+}
+
+double UnrealizedPnL::calculate() const
+{
+    return equity.empty() ? 0.0 : equity.back() - equity.front();
+}
+
+double Turnover::calculate() const
+{
+    double t = 0.0;
+    for (const auto& e : trades)
+        t += e.qty * e.price;
+    return t;
+}
+
+double MaxAbsInventory::calculate() const
+{
+    double mx = 0.0;
+    for (double v : inv)
+        mx = std::max(mx, std::abs(v));
+    return mx;
+}
+
+double TimeWeightedAvgInventory::calculate() const
+{
+    const std::size_t n = std::min(inv.size(), ts.size());
+    if (n < 2)
+        return inv.empty() ? 0.0 : std::abs(inv.front());
+    double sumW = 0.0;
+    double sumWV = 0.0;
+    for (std::size_t i = 1; i < n; ++i)
+    {
+        const double dt = static_cast<double>(ts[i] - ts[i - 1]);
+        sumW += dt;
+        sumWV += std::abs(inv[i - 1]) * dt;
+    }
+    return sumW > 0.0 ? sumWV / sumW : 0.0;
+}
+
+double SharpeAnnualized::calculate() const
+{
+    if (rets.size() < 2)
+        return 0.0;
+    const double n = static_cast<double>(rets.size());
+    const double mean = std::accumulate(rets.begin(), rets.end(), 0.0) / n;
+    double var = 0.0;
+    for (double r : rets)
+        var += (r - mean) * (r - mean);
+    var /= (n - 1.0);
+    const double sd = std::sqrt(var);
+    return sd > 0.0 ? mean / sd * std::sqrt(stepsPerYear) : 0.0;
+}
+
+double SortinoAnnualized::calculate() const
+{
+    if (rets.size() < 2)
+        return 0.0;
+    const double n = static_cast<double>(rets.size());
+    const double mean = std::accumulate(rets.begin(), rets.end(), 0.0) / n;
+    double downVar = 0.0;
+    std::size_t cnt = 0;
+    for (double r : rets)
+    {
+        if (r < 0.0)
+        {
+            downVar += r * r;
+            ++cnt;
+        }
+    }
+    if (cnt == 0)
+        return 0.0;
+    const double downSd = std::sqrt(downVar / static_cast<double>(cnt));
+    return downSd > 0.0 ? mean / downSd * std::sqrt(stepsPerYear) : 0.0;
+}
+
+double MaxDrawdownPct::calculate() const
+{
+    double peak = -std::numeric_limits<double>::infinity();
+    double maxDd = 0.0;
+    for (double v : equity)
+    {
+        if (v > peak)
+            peak = v;
+        if (peak > 0.0)
+        {
+            const double dd = (peak - v) / peak * 100.0;
+            if (dd > maxDd)
+                maxDd = dd;
+        }
+    }
+    return maxDd;
+}
+
+} // namespace cmf

--- a/src/engine/Metrics.hpp
+++ b/src/engine/Metrics.hpp
@@ -1,0 +1,101 @@
+#pragma once
+
+#include "engine/Types.hpp"
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace cmf
+{
+
+struct Metric
+{
+    virtual ~Metric() = default;
+    virtual std::string name() const = 0;
+    virtual double calculate() const = 0;
+};
+
+struct RealizedPnL : Metric
+{
+    const std::vector<TradeRecord>& trades;
+    explicit RealizedPnL(const std::vector<TradeRecord>& t) : trades(t) {}
+    std::string name() const override { return "realized_pnl"; }
+    double calculate() const override;
+};
+
+struct UnrealizedPnL : Metric
+{
+    const std::vector<double>& equity;
+    explicit UnrealizedPnL(const std::vector<double>& e) : equity(e) {}
+    std::string name() const override { return "unrealized_pnl"; }
+    double calculate() const override;
+};
+
+struct Turnover : Metric
+{
+    const std::vector<TradeRecord>& trades;
+    explicit Turnover(const std::vector<TradeRecord>& t) : trades(t) {}
+    std::string name() const override { return "turnover"; }
+    double calculate() const override;
+};
+
+struct MaxAbsInventory : Metric
+{
+    const std::vector<double>& inv;
+    explicit MaxAbsInventory(const std::vector<double>& i) : inv(i) {}
+    std::string name() const override { return "max_abs_inventory"; }
+    double calculate() const override;
+};
+
+struct TimeWeightedAvgInventory : Metric
+{
+    const std::vector<double>& inv;
+    const std::vector<NanoTime>& ts;
+    TimeWeightedAvgInventory(const std::vector<double>& i, const std::vector<NanoTime>& t)
+        : inv(i), ts(t)
+    {
+    }
+    std::string name() const override { return "twap_inventory"; }
+    double calculate() const override;
+};
+
+struct FillRatio : Metric
+{
+    std::uint64_t sent;
+    std::uint64_t filled;
+    FillRatio(std::uint64_t s, std::uint64_t f) : sent(s), filled(f) {}
+    std::string name() const override { return "fill_ratio"; }
+    double calculate() const override
+    {
+        return sent > 0 ? static_cast<double>(filled) / static_cast<double>(sent) : 0.0;
+    }
+};
+
+struct SharpeAnnualized : Metric
+{
+    const std::vector<double>& rets;
+    double stepsPerYear;
+    SharpeAnnualized(const std::vector<double>& r, double spY) : rets(r), stepsPerYear(spY) {}
+    std::string name() const override { return "sharpe"; }
+    double calculate() const override;
+};
+
+struct SortinoAnnualized : Metric
+{
+    const std::vector<double>& rets;
+    double stepsPerYear;
+    SortinoAnnualized(const std::vector<double>& r, double spY) : rets(r), stepsPerYear(spY) {}
+    std::string name() const override { return "sortino"; }
+    double calculate() const override;
+};
+
+struct MaxDrawdownPct : Metric
+{
+    const std::vector<double>& equity;
+    explicit MaxDrawdownPct(const std::vector<double>& e) : equity(e) {}
+    std::string name() const override { return "max_drawdown_pct"; }
+    double calculate() const override;
+};
+
+} // namespace cmf

--- a/src/engine/OrderBook.hpp
+++ b/src/engine/OrderBook.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "engine/Types.hpp"
+#include <algorithm>
+
+namespace cmf
+{
+
+class OrderBook
+{
+public:
+    // VWAP fill across visible depth; residual takes last level price.
+    static ExecReport execute_market(const Order& order, const L2Snapshot& book)
+    {
+        const bool isBuy = order.side == Side::Buy;
+        const auto& levels = isBuy ? book.asks : book.bids;
+        double toFill = order.amount;
+        double cost = 0.0;
+        double filled = 0.0;
+        for (const auto& lvl : levels)
+        {
+            if (toFill <= 0.0)
+                break;
+            const double take = std::min(toFill, lvl.amount);
+            cost += take * lvl.price;
+            filled += take;
+            toFill -= take;
+        }
+        if (toFill > 0.0 && !levels.empty())
+        {
+            cost += toFill * levels.back().price;
+            filled += toFill;
+        }
+        return {order.id, filled, filled > 0.0 ? cost / filled : 0.0, book.ts};
+    }
+
+    static bool limit_crossed(const Order& order, const L2Snapshot& book)
+    {
+        if (order.type != OrderType::Limit)
+            return false;
+        if (order.side == Side::Buy)
+            return !book.asks.empty() && book.asks.front().price <= order.price;
+        return !book.bids.empty() && book.bids.front().price >= order.price;
+    }
+
+    // Passive maker fill at own limit price, qty capped by contraQty.
+    static ExecReport passive_fill(const Order& order, double contraQty, NanoTime ts)
+    {
+        const double qty = std::min(order.amount, contraQty);
+        return {order.id, qty, order.price, ts};
+    }
+
+    // Aggressor taker fill at best contra price.
+    static ExecReport aggressor_fill(const Order& order, const L2Snapshot& book)
+    {
+        const auto& contra = (order.side == Side::Buy) ? book.asks : book.bids;
+        if (contra.empty())
+            return {order.id, 0.0, 0.0, book.ts};
+        return {order.id, order.amount, contra.front().price, book.ts};
+    }
+};
+
+} // namespace cmf

--- a/src/engine/Types.hpp
+++ b/src/engine/Types.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "common/BasicTypes.hpp"
+#include <vector>
+
+namespace cmf
+{
+
+struct Level
+{
+    Price price{0.0};
+    Quantity amount{0.0};
+};
+
+struct L2Snapshot
+{
+    NanoTime ts{0};
+    std::vector<Level> asks;
+    std::vector<Level> bids;
+};
+
+struct TradeEvent
+{
+    NanoTime ts{0};
+    Side side{Side::None};
+    Price price{0.0};
+    Quantity amount{0.0};
+};
+
+struct Order
+{
+    ClOrdId id{0};
+    OrderType type{OrderType::None};
+    Side side{Side::None};
+    Price price{0.0};
+    Quantity amount{0.0};
+    NanoTime ts{0};
+};
+
+struct ExecReport
+{
+    ClOrdId orderId{0};
+    Quantity filled{0.0};
+    Price avgPrice{0.0};
+    NanoTime ts{0};
+};
+
+struct TradeRecord
+{
+    NanoTime ts{0};
+    Quantity qty{0.0};
+    Price price{0.0};
+    Side side{Side::None};
+    double fee{0.0};
+};
+
+struct Fees
+{
+    double maker{0.0};
+    double taker{0.0};
+};
+
+struct Portfolio
+{
+    double cash{0.0};
+    Quantity position{0.0};
+};
+
+} // namespace cmf

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(TARGET hft-market-making-io)
+file(GLOB SRC CONFIGURE_DEPENDS *.cpp)
+add_library(${TARGET} STATIC ${SRC})
+target_link_libraries(${TARGET} PUBLIC hft-market-making-engine)

--- a/src/io/CsvReader.cpp
+++ b/src/io/CsvReader.cpp
@@ -1,0 +1,127 @@
+#include "io/CsvReader.hpp"
+#include <sstream>
+
+namespace cmf
+{
+
+static bool getline_stripped(std::ifstream& f, std::string& out)
+{
+    if (!std::getline(f, out))
+        return false;
+    while (!out.empty() && (out.back() == '\r' || out.back() == '\n'))
+        out.pop_back();
+    return true;
+}
+
+CsvL2Reader::CsvL2Reader(const std::string& path) : file_(path)
+{
+    std::string header;
+    getline_stripped(file_, header);
+    std::vector<std::string> cols;
+    std::stringstream hs(header);
+    std::string colname;
+    while (std::getline(hs, colname, ','))
+        cols.push_back(colname);
+
+    for (std::size_t i = 0; i < cols.size(); ++i)
+    {
+        const std::string& col = cols[i];
+        const bool isAsk = (col.rfind("asks[", 0) == 0);
+        const bool isBid = (col.rfind("bids[", 0) == 0);
+        if (!isAsk && !isBid)
+            continue;
+        const auto bracket = col.find(']');
+        if (bracket == std::string::npos)
+            continue;
+        const int k = std::stoi(col.substr(5, bracket - 5));
+        const bool isPrice = (col.find("price") != std::string::npos);
+        const bool isAmount = (col.find("amount") != std::string::npos);
+        const int idx = static_cast<int>(i);
+
+        auto ensure = [](std::vector<int>& v, int sz) {
+            if (static_cast<int>(v.size()) <= sz)
+                v.resize(static_cast<std::size_t>(sz + 1), -1);
+        };
+
+        if (isAsk && isPrice)
+        {
+            ensure(askIdxPrice_, k);
+            askIdxPrice_[static_cast<std::size_t>(k)] = idx;
+        }
+        else if (isAsk && isAmount)
+        {
+            ensure(askIdxAmount_, k);
+            askIdxAmount_[static_cast<std::size_t>(k)] = idx;
+        }
+        else if (isBid && isPrice)
+        {
+            ensure(bidIdxPrice_, k);
+            bidIdxPrice_[static_cast<std::size_t>(k)] = idx;
+        }
+        else if (isBid && isAmount)
+        {
+            ensure(bidIdxAmount_, k);
+            bidIdxAmount_[static_cast<std::size_t>(k)] = idx;
+        }
+    }
+    const int ap = static_cast<int>(askIdxPrice_.size());
+    const int aa = static_cast<int>(askIdxAmount_.size());
+    const int bp = static_cast<int>(bidIdxPrice_.size());
+    const int ba = static_cast<int>(bidIdxAmount_.size());
+    depth_ = std::min(std::min(ap, aa), std::min(bp, ba));
+}
+
+bool CsvL2Reader::next(L2Snapshot& out)
+{
+    std::string line;
+    if (!getline_stripped(file_, line))
+        return false;
+    std::vector<std::string> cells;
+    cells.reserve(static_cast<std::size_t>(2 + 4 * depth_));
+    std::stringstream ss(line);
+    std::string cell;
+    while (std::getline(ss, cell, ','))
+        cells.push_back(cell);
+
+    out.ts = static_cast<NanoTime>(std::stoll(cells[1]));
+    out.asks.clear();
+    out.bids.clear();
+    for (int k = 0; k < depth_; ++k)
+    {
+        const auto ks = static_cast<std::size_t>(k);
+        const double ap = std::stod(cells[static_cast<std::size_t>(askIdxPrice_[ks])]);
+        const double aa = std::stod(cells[static_cast<std::size_t>(askIdxAmount_[ks])]);
+        const double bp = std::stod(cells[static_cast<std::size_t>(bidIdxPrice_[ks])]);
+        const double ba = std::stod(cells[static_cast<std::size_t>(bidIdxAmount_[ks])]);
+        out.asks.push_back({ap, aa});
+        out.bids.push_back({bp, ba});
+    }
+    return true;
+}
+
+CsvTradesReader::CsvTradesReader(const std::string& path) : file_(path)
+{
+    std::string header;
+    getline_stripped(file_, header);
+}
+
+bool CsvTradesReader::next(TradeEvent& out)
+{
+    std::string line;
+    if (!getline_stripped(file_, line))
+        return false;
+    std::stringstream ss(line);
+    std::string cell;
+    std::getline(ss, cell, ','); // index
+    std::getline(ss, cell, ',');
+    out.ts = static_cast<NanoTime>(std::stoll(cell));
+    std::getline(ss, cell, ',');
+    out.side = (cell == "buy") ? Side::Buy : Side::Sell;
+    std::getline(ss, cell, ',');
+    out.price = std::stod(cell);
+    std::getline(ss, cell, ',');
+    out.amount = std::stod(cell);
+    return true;
+}
+
+} // namespace cmf

--- a/src/io/CsvReader.hpp
+++ b/src/io/CsvReader.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "engine/Engine.hpp"
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace cmf
+{
+
+class CsvL2Reader : public IL2Reader
+{
+public:
+    explicit CsvL2Reader(const std::string& path);
+    bool next(L2Snapshot& out) override;
+
+private:
+    std::ifstream file_;
+    int depth_{0};
+    std::vector<int> askIdxPrice_, askIdxAmount_, bidIdxPrice_, bidIdxAmount_;
+};
+
+class CsvTradesReader : public ITradesReader
+{
+public:
+    explicit CsvTradesReader(const std::string& path);
+    bool next(TradeEvent& out) override;
+
+private:
+    std::ifstream file_;
+};
+
+} // namespace cmf

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -1,14 +1,5 @@
-file(GLOB SRC CONFIGURE_DEPENDS *.cpp)
-list(REMOVE_ITEM SRC main.cpp)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-# static library
-set(TARGET hft-market-making-lib)
-add_library(${TARGET} STATIC ${SRC})
-target_link_libraries(${TARGET} PUBLIC
-    hft-market-making-common
-)
-
-# executable
 set(TARGET hft-market-making)
 add_executable(${TARGET} main.cpp)
-target_link_libraries(${TARGET} PUBLIC hft-market-making-lib)
+target_link_libraries(${TARGET} PRIVATE hft-market-making-strategy)

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -1,23 +1,126 @@
-// main function for the hft-market-making app
-// please, keep it minimalistic
+#include "engine/Engine.hpp"
+#include "engine/LatencyModel.hpp"
+#include "engine/Metrics.hpp"
+#include "io/CsvReader.hpp"
+#include "strategy/AvellanedaStoikov.hpp"
+#include "strategy/Config.hpp"
+#include "strategy/Intensity.hpp"
 
-#include "common/BasicTypes.hpp"
-
+#include <fstream>
 #include <iostream>
+#include <string>
 
 using namespace cmf;
 
-int main([[maybe_unused]] int argc, [[maybe_unused]] const char* argv[])
+static void write_csv(const std::string& path, const std::string& header,
+                      const std::vector<std::string>& rows)
 {
-    try
+    std::ofstream f(path);
+    f << header << "\n";
+    for (const auto& r : rows)
+        f << r << "\n";
+}
+
+int main(int argc, char** argv)
+{
+    KvConfig cfg = KvConfig::from_file(argc > 1 ? argv[1] : "");
+    cfg.apply_cli_overrides(argc, argv);
+
+    const std::string lobPath = cfg.get_string("data.lob", "lob.csv");
+    const std::string trdPath = cfg.get_string("data.trades", "trades.csv");
+    const double gamma = cfg.get_double("gamma", 0.1);
+    const double volHalfLife = cfg.get_double("vol_halflife_ticks", 2000.0);
+    const double invCap = cfg.get_double("inv_cap", 10000.0);
+    const double baseQty = cfg.get_double("base_qty", 1000.0);
+    const double sessionTicks = cfg.get_double("session_horizon_ticks", 1e6);
+    const double latencyNs = cfg.get_double("latency_ns", 500000.0);
+    const double feesMaker = cfg.get_double("fees.maker", -0.00005);
+    const double feesTaker = cfg.get_double("fees.taker", 0.0007);
+    const RefPriceMode mode = cfg.get_string("ref_price_mode", "mid") == "microprice"
+                                  ? RefPriceMode::Microprice
+                                  : RefPriceMode::Mid;
+
+    double k;
+    if (cfg.has("k"))
     {
-        std::cout << "Hell! Oh, world!" << std::endl;
+        k = cfg.get_double("k", 1.5);
+        std::cout << "k=" << k << " (from config)\n";
     }
-    catch (std::exception& ex)
+    else
     {
-        std::cerr << "HFT market-making app threw an exception: " << ex.what() << std::endl;
-        return 1;
+        FitConfig fitCfg;
+        fitCfg.buckets = cfg.get_int("intensity_fit_buckets", 20);
+        fitCfg.maxDist = cfg.get_double("intensity_fit_max_dist", 5e-4);
+        fitCfg.maxTrades = static_cast<std::size_t>(
+            cfg.get_int("intensity_fit_max_trades", 2000000));
+        const auto fit = fit_intensity_from_csvs(lobPath, trdPath, fitCfg);
+        k = fit.valid ? fit.k : 1.5;
+        std::cout << "intensity_fit: k=" << k << " A=" << fit.A
+                  << " R2=" << fit.r2 << (fit.valid ? "" : " (fallback)") << "\n";
     }
+
+    Logger::set_path("stoikov_mm.log");
+    Fees fees{feesMaker, feesTaker};
+    auto latency = std::make_unique<ConstLatency>(static_cast<NanoTime>(latencyNs));
+    auto strat = std::make_unique<AvellanedaStoikovMM>(
+        mode, gamma, k, sessionTicks, invCap, baseQty, volHalfLife);
+    BacktestEngine eng(std::move(latency), std::move(strat), fees);
+    eng.set_l2_reader(std::make_unique<CsvL2Reader>(lobPath));
+    eng.set_trades_reader(std::make_unique<CsvTradesReader>(trdPath));
+    eng.run();
+
+    const auto& execs = eng.executions();
+    const auto& eq = eng.equity_series();
+    const auto& ts = eng.equity_ts_series();
+    const auto& inv = eng.inventory_series();
+
+    {
+        std::vector<std::string> rows;
+        rows.reserve(execs.size());
+        for (const auto& e : execs)
+            rows.push_back(std::to_string(e.ts) + ","
+                           + (e.side == Side::Buy ? "buy" : "sell") + ","
+                           + std::to_string(e.qty) + ","
+                           + std::to_string(e.price) + ","
+                           + std::to_string(e.fee));
+        write_csv("executions.csv", "ts,side,qty,price,fee", rows);
+    }
+    {
+        std::vector<std::string> rows;
+        const std::size_t n = std::min({eq.size(), ts.size(), inv.size()});
+        rows.reserve(n);
+        for (std::size_t i = 0; i < n; ++i)
+            rows.push_back(std::to_string(ts[i]) + ","
+                           + std::to_string(eq[i]) + ","
+                           + std::to_string(inv[i]));
+        write_csv("equity.csv", "ts,equity,inventory", rows);
+    }
+
+    const double spY = eng.estimated_steps_per_year();
+
+    RealizedPnL realizedPnL(execs);
+    UnrealizedPnL unrealizedPnL(eq);
+    Turnover turnover(execs);
+    MaxAbsInventory maxInv(inv);
+    TimeWeightedAvgInventory twapInv(inv, ts);
+    FillRatio fillRatio(eng.sent_count(), eng.filled_count());
+    SharpeAnnualized sharpe(eng.unrealized_returns_series(), spY);
+    SortinoAnnualized sortino(eng.unrealized_returns_series(), spY);
+    MaxDrawdownPct mdd(eq);
+
+    std::cout << "metric,value\n"
+              << "realized_pnl," << realizedPnL.calculate() << "\n"
+              << "unrealized_pnl," << unrealizedPnL.calculate() << "\n"
+              << "turnover," << turnover.calculate() << "\n"
+              << "max_inventory," << maxInv.calculate() << "\n"
+              << "twap_inventory," << twapInv.calculate() << "\n"
+              << "fill_ratio," << fillRatio.calculate() << "\n"
+              << "sharpe," << sharpe.calculate() << "\n"
+              << "sortino," << sortino.calculate() << "\n"
+              << "max_drawdown_pct," << mdd.calculate() << "\n"
+              << "fills," << execs.size() << "\n"
+              << "k," << k << "\n"
+              << "gamma," << gamma << "\n";
 
     return 0;
 }

--- a/src/strategy/AvellanedaStoikov.hpp
+++ b/src/strategy/AvellanedaStoikov.hpp
@@ -1,0 +1,91 @@
+#pragma once
+
+#include "engine/Engine.hpp"
+#include "strategy/Microprice.hpp"
+#include "strategy/Volatility.hpp"
+#include <cmath>
+
+namespace cmf
+{
+
+enum class RefPriceMode
+{
+    Mid,
+    Microprice
+};
+
+struct AvellanedaStoikovMM : Strategy
+{
+    RefPriceMode mode;
+    double gamma;
+    double k;
+    double sessionTicks;
+    double invCap;
+    double baseQty;
+    EwmaVariance vol;
+    double position{0.0};
+    double tickCount{0.0};
+    ClOrdId bidId{0};
+    ClOrdId askId{0};
+
+    AvellanedaStoikovMM(RefPriceMode m, double g, double k_,
+                        double sessionT, double cap, double qty, double halfLife)
+        : mode(m), gamma(g), k(k_), sessionTicks(sessionT),
+          invCap(cap), baseQty(qty), vol(halfLife)
+    {
+    }
+
+    void on_l2(const L2Snapshot& l2, StrategyContext& ctx) override
+    {
+        if (l2.asks.empty() || l2.bids.empty())
+            return;
+        const double s = (mode == RefPriceMode::Microprice) ? microprice(l2) : mid(l2);
+        vol.update(s);
+        tickCount += 1.0;
+        if (!vol.initialized())
+            return;
+
+        const double sigma2 = vol.value();
+        const double tRemaining = std::max(0.0, sessionTicks - tickCount);
+        const double r = s - position * gamma * sigma2 * tRemaining;
+        const double halfSpread = 0.5 * gamma * sigma2 * tRemaining
+                                  + (1.0 / gamma) * std::log1p(gamma / k);
+        if (halfSpread <= 0.0 || !std::isfinite(r) || !std::isfinite(halfSpread))
+            return;
+
+        if (bidId)
+        {
+            ctx.cancel_order(bidId);
+            bidId = 0;
+        }
+        if (askId)
+        {
+            ctx.cancel_order(askId);
+            askId = 0;
+        }
+
+        if (position < invCap)
+        {
+            Order ob{0, OrderType::Limit, Side::Buy, r - halfSpread, baseQty, l2.ts};
+            bidId = ctx.send_order(ob);
+        }
+        if (position > -invCap)
+        {
+            Order oa{0, OrderType::Limit, Side::Sell, r + halfSpread, baseQty, l2.ts};
+            askId = ctx.send_order(oa);
+        }
+    }
+
+    void on_fill(const ExecReport& rep, Side side, bool, StrategyContext&) override
+    {
+        position += (side == Side::Buy ? 1.0 : -1.0) * rep.filled;
+        if (side == Side::Buy && rep.orderId == bidId)
+            bidId = 0;
+        if (side == Side::Sell && rep.orderId == askId)
+            askId = 0;
+    }
+
+    void on_trade(const TradeEvent&, StrategyContext&) override {}
+};
+
+} // namespace cmf

--- a/src/strategy/CMakeLists.txt
+++ b/src/strategy/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(TARGET hft-market-making-strategy)
+file(GLOB SRC CONFIGURE_DEPENDS *.cpp)
+add_library(${TARGET} STATIC ${SRC})
+target_link_libraries(${TARGET} PUBLIC hft-market-making-io)

--- a/src/strategy/Config.hpp
+++ b/src/strategy/Config.hpp
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <algorithm>
+#include <charconv>
+#include <fstream>
+#include <string>
+#include <unordered_map>
+
+namespace cmf
+{
+
+class KvConfig
+{
+    std::unordered_map<std::string, std::string> data_;
+
+    static std::string trim(std::string s)
+    {
+        const auto notSpace = [](unsigned char c) { return !std::isspace(c); };
+        s.erase(s.begin(), std::find_if(s.begin(), s.end(), notSpace));
+        s.erase(std::find_if(s.rbegin(), s.rend(), notSpace).base(), s.end());
+        return s;
+    }
+
+public:
+    static KvConfig from_file(const std::string& path)
+    {
+        KvConfig cfg;
+        if (path.empty())
+            return cfg;
+        std::ifstream f(path);
+        if (!f)
+            return cfg;
+        std::string line;
+        while (std::getline(f, line))
+        {
+            const auto hash = line.find('#');
+            if (hash != std::string::npos)
+                line.erase(hash);
+            const auto eq = line.find('=');
+            if (eq == std::string::npos)
+                continue;
+            auto key = trim(line.substr(0, eq));
+            auto val = trim(line.substr(eq + 1));
+            if (!key.empty())
+                cfg.data_[std::move(key)] = std::move(val);
+        }
+        return cfg;
+    }
+
+    void apply_cli_overrides(int argc, char** argv)
+    {
+        for (int i = 1; i < argc; ++i)
+        {
+            std::string a = argv[i];
+            if (a.rfind("--", 0) != 0)
+                continue;
+            a.erase(0, 2);
+            const auto eq = a.find('=');
+            if (eq == std::string::npos)
+                continue;
+            data_[trim(a.substr(0, eq))] = trim(a.substr(eq + 1));
+        }
+    }
+
+    double get_double(const std::string& key, double def) const
+    {
+        const auto it = data_.find(key);
+        if (it == data_.end())
+            return def;
+        double v = def;
+        std::from_chars(it->second.data(), it->second.data() + it->second.size(), v);
+        return v;
+    }
+
+    int get_int(const std::string& key, int def) const
+    {
+        const auto it = data_.find(key);
+        if (it == data_.end())
+            return def;
+        int v = def;
+        std::from_chars(it->second.data(), it->second.data() + it->second.size(), v);
+        return v;
+    }
+
+    std::string get_string(const std::string& key, const std::string& def = {}) const
+    {
+        const auto it = data_.find(key);
+        return it == data_.end() ? def : it->second;
+    }
+
+    bool has(const std::string& key) const { return data_.count(key) > 0; }
+};
+
+} // namespace cmf

--- a/src/strategy/Intensity.cpp
+++ b/src/strategy/Intensity.cpp
@@ -1,0 +1,128 @@
+#include "strategy/Intensity.hpp"
+#include "io/CsvReader.hpp"
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+namespace cmf
+{
+
+namespace
+{
+
+struct OlsResult
+{
+    double a, b, r2;
+};
+
+OlsResult ols(const std::vector<double>& x, const std::vector<double>& y)
+{
+    const int n = static_cast<int>(x.size());
+    if (n < 2)
+        return {0.0, 0.0, 0.0};
+    double sx = 0.0, sy = 0.0, sxy = 0.0, sxx = 0.0;
+    for (int i = 0; i < n; ++i)
+    {
+        sx += x[i];
+        sy += y[i];
+        sxy += x[i] * y[i];
+        sxx += x[i] * x[i];
+    }
+    const double denom = n * sxx - sx * sx;
+    if (std::abs(denom) < 1e-15)
+        return {sy / n, 0.0, 0.0};
+    const double b = (n * sxy - sx * sy) / denom;
+    const double a = (sy - b * sx) / n;
+    const double yMean = sy / n;
+    double ssTot = 0.0, ssRes = 0.0;
+    for (int i = 0; i < n; ++i)
+    {
+        const double dy = y[i] - yMean;
+        const double dr = y[i] - (a + b * x[i]);
+        ssTot += dy * dy;
+        ssRes += dr * dr;
+    }
+    const double r2 = ssTot > 0.0 ? 1.0 - ssRes / ssTot : 0.0;
+    return {a, b, r2};
+}
+
+} // namespace
+
+IntensityFit fit_intensity_from_csvs(
+    const std::string& lobPath,
+    const std::string& tradesPath,
+    const FitConfig& cfg)
+{
+    CsvL2Reader l2Reader(lobPath);
+    CsvTradesReader trdReader(tradesPath);
+
+    L2Snapshot l2{};
+    TradeEvent t{};
+    bool hasL2 = l2Reader.next(l2);
+    bool hasTrd = trdReader.next(t);
+
+    std::vector<std::size_t> counts(static_cast<std::size_t>(cfg.buckets), 0);
+    const double bucketWidth = cfg.maxDist / cfg.buckets;
+
+    double lastMid = 0.0;
+    NanoTime firstTs = 0, lastTs = 0;
+    std::size_t tradeSeen = 0;
+
+    while ((hasL2 || hasTrd) && tradeSeen < cfg.maxTrades)
+    {
+        if (hasL2 && (!hasTrd || l2.ts <= t.ts))
+        {
+            if (!l2.asks.empty() && !l2.bids.empty())
+                lastMid = 0.5 * (l2.asks.front().price + l2.bids.front().price);
+            hasL2 = l2Reader.next(l2);
+            continue;
+        }
+        if (!hasTrd)
+            break;
+        if (lastMid <= 0.0)
+        {
+            hasTrd = trdReader.next(t);
+            continue;
+        }
+
+        const double dist = std::abs(t.price - lastMid);
+        if (dist < cfg.maxDist)
+        {
+            const int bin = std::min(cfg.buckets - 1,
+                                     static_cast<int>(dist / bucketWidth));
+            ++counts[static_cast<std::size_t>(bin)];
+            if (firstTs == 0)
+                firstTs = t.ts;
+            lastTs = t.ts;
+        }
+        ++tradeSeen;
+        hasTrd = trdReader.next(t);
+    }
+
+    const double spanSec = (lastTs > firstTs)
+                               ? static_cast<double>(lastTs - firstTs) / 1e9
+                               : 1.0;
+    if (spanSec <= 0.0 || tradeSeen < 100)
+        return {};
+
+    std::vector<double> xs, ys;
+    for (int i = 0; i < cfg.buckets; ++i)
+    {
+        const std::size_t cnt = counts[static_cast<std::size_t>(i)];
+        if (cnt == 0)
+            continue;
+        const double delta = (i + 0.5) * bucketWidth;
+        const double lambda = static_cast<double>(cnt) / spanSec;
+        xs.push_back(delta);
+        ys.push_back(std::log(lambda));
+    }
+    if (xs.size() < 3)
+        return {};
+
+    const auto res = ols(xs, ys);
+    const double k = std::max(0.01, -res.b);
+    const double A = std::exp(res.a);
+    return {A, k, res.r2, true};
+}
+
+} // namespace cmf

--- a/src/strategy/Intensity.hpp
+++ b/src/strategy/Intensity.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+namespace cmf
+{
+
+struct FitConfig
+{
+    int buckets{20};
+    double maxDist{5e-4};
+    std::size_t maxTrades{2'000'000};
+};
+
+struct IntensityFit
+{
+    double A{1.0};
+    double k{1.5};
+    double r2{0.0};
+    bool valid{false};
+};
+
+IntensityFit fit_intensity_from_csvs(
+    const std::string& lobPath,
+    const std::string& tradesPath,
+    const FitConfig& cfg = {});
+
+} // namespace cmf

--- a/src/strategy/Microprice.hpp
+++ b/src/strategy/Microprice.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "engine/Types.hpp"
+
+namespace cmf
+{
+
+inline double mid(const L2Snapshot& l2)
+{
+    if (l2.asks.empty() || l2.bids.empty())
+        return 0.0;
+    return 0.5 * (l2.asks.front().price + l2.bids.front().price);
+}
+
+// Stoikov (2018): probability-weighted expected future mid price.
+// Large bid queue relative to ask queue pushes microprice toward the ask.
+inline double microprice(const L2Snapshot& l2)
+{
+    if (l2.asks.empty() || l2.bids.empty())
+        return 0.0;
+    const double pa = l2.asks.front().price;
+    const double pb = l2.bids.front().price;
+    const double va = l2.asks.front().amount;
+    const double vb = l2.bids.front().amount;
+    const double total = va + vb;
+    if (total <= 0.0)
+        return 0.5 * (pa + pb);
+    return (pa * vb + pb * va) / total;
+}
+
+} // namespace cmf

--- a/src/strategy/Volatility.hpp
+++ b/src/strategy/Volatility.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <cmath>
+#include <cstddef>
+#include <limits>
+
+namespace cmf
+{
+
+struct EwmaVariance
+{
+    double lambda;
+    double s2{0.0};
+    double prevLogPx{std::numeric_limits<double>::quiet_NaN()};
+    std::size_t n{0};
+    double cap;
+
+    explicit EwmaVariance(double halfLifeTicks, double maxVar = 1e-3)
+        : lambda(std::exp(-std::log(2.0) / halfLifeTicks)), cap(maxVar)
+    {
+    }
+
+    void update(double px)
+    {
+        if (px <= 0.0)
+            return;
+        const double logPx = std::log(px);
+        if (std::isnan(prevLogPx))
+        {
+            prevLogPx = logPx;
+            return;
+        }
+        const double r = logPx - prevLogPx;
+        prevLogPx = logPx;
+        ++n;
+        s2 = n == 1 ? std::min(cap, r * r)
+                    : std::min(cap, lambda * s2 + (1.0 - lambda) * r * r);
+    }
+
+    double value() const { return s2; }
+    bool initialized() const { return n >= 2; }
+};
+
+} // namespace cmf

--- a/test/AsQuotesTest.cpp
+++ b/test/AsQuotesTest.cpp
@@ -1,0 +1,110 @@
+#include "strategy/AvellanedaStoikov.hpp"
+#include "engine/Engine.hpp"
+
+#include "catch2/catch_all.hpp"
+
+#include <cmath>
+
+using namespace cmf;
+
+// Closed-form A-S half-spread: gamma*sigma2*(T-t)/2 + (1/gamma)*ln(1+gamma/k)
+static double as_half_spread(double gamma, double sigma2, double tRem, double k)
+{
+    return 0.5 * gamma * sigma2 * tRem + (1.0 / gamma) * std::log1p(gamma / k);
+}
+
+// Closed-form reservation price: s - q * gamma * sigma2 * (T-t)
+static double as_reservation(double s, double q, double gamma, double sigma2, double tRem)
+{
+    return s - q * gamma * sigma2 * tRem;
+}
+
+TEST_CASE("A-S half-spread matches closed form", "[AsQuotes]")
+{
+    const double gamma = 0.1, k = 1.5, sigma2 = 1e-6, tRem = 1000.0;
+    const double expected = as_half_spread(gamma, sigma2, tRem, k);
+    const double computed = 0.5 * gamma * sigma2 * tRem + (1.0 / gamma) * std::log1p(gamma / k);
+    REQUIRE(computed == Catch::Approx(expected).epsilon(1e-9));
+}
+
+TEST_CASE("A-S reservation price sign flips with inventory", "[AsQuotes]")
+{
+    const double gamma = 0.1, sigma2 = 1e-6, tRem = 1000.0, s = 100.0;
+    const double rPos = as_reservation(s, +5000.0, gamma, sigma2, tRem);
+    const double rNeg = as_reservation(s, -5000.0, gamma, sigma2, tRem);
+    REQUIRE(rPos < s);
+    REQUIRE(rNeg > s);
+    // symmetric around s
+    REQUIRE((rPos - s) == Catch::Approx(-(rNeg - s)).epsilon(1e-9));
+}
+
+TEST_CASE("A-S half-spread is independent of inventory", "[AsQuotes]")
+{
+    const double gamma = 0.1, k = 1.5, sigma2 = 1e-6, tRem = 1000.0;
+    const double d1 = as_half_spread(gamma, sigma2, tRem, k);
+    // half-spread formula does not involve q at all
+    REQUIRE(d1 > 0.0);
+    // just verify it's positive for several gamma values
+    for (double g : {0.01, 0.1, 1.0})
+        REQUIRE(as_half_spread(g, sigma2, tRem, k) > 0.0);
+}
+
+TEST_CASE("A-S half-spread is positive", "[AsQuotes]")
+{
+    for (double tRem : {0.0, 100.0, 1e6})
+        REQUIRE(as_half_spread(0.1, 1e-6, tRem, 1.5) >= 0.0);
+}
+
+TEST_CASE("A-S strategy quotes straddle reservation price", "[AsQuotes]")
+{
+    // Drive the strategy through a mock engine context to verify bid < r < ask.
+    // We don't run the full engine; just call on_l2 directly with a fake context.
+    ClOrdId lastBidId = 0, lastAskId = 0;
+    double lastBidPx = 0.0, lastAskPx = 0.0;
+
+    StrategyContext ctx;
+    ctx.send_order = [&](const Order& o) -> ClOrdId
+    {
+        static ClOrdId seq = 1;
+        if (o.side == Side::Buy)
+        {
+            lastBidId = seq;
+            lastBidPx = o.price;
+        }
+        else
+        {
+            lastAskId = seq;
+            lastAskPx = o.price;
+        }
+        return seq++;
+    };
+    ctx.cancel_order = [](ClOrdId) {};
+
+    AvellanedaStoikovMM strat(RefPriceMode::Mid, 0.1, 1.5, 1e6, 1e9, 1.0, 50.0);
+
+    // Warm up vol
+    L2Snapshot warmup;
+    warmup.bids.push_back({99.9, 1.0});
+    warmup.asks.push_back({100.1, 1.0});
+    warmup.ts = 1000;
+    for (int i = 0; i < 10; ++i)
+    {
+        warmup.ts += 1;
+        warmup.bids[0].price = 100.0 + (i % 3) * 0.0001;
+        warmup.asks[0].price = warmup.bids[0].price + 0.0002;
+        strat.on_l2(warmup, ctx);
+    }
+
+    // Final tick: flat book at 100.0 / 100.002
+    L2Snapshot s;
+    s.bids.push_back({100.0, 5.0});
+    s.asks.push_back({100.002, 5.0});
+    s.ts = 2000;
+    strat.on_l2(s, ctx);
+
+    REQUIRE(lastBidPx > 0.0);
+    REQUIRE(lastAskPx > 0.0);
+    REQUIRE(lastBidPx < 100.001); // bid below mid
+    REQUIRE(lastAskPx > 100.001); // ask above mid
+    REQUIRE(lastAskPx > lastBidPx);
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,6 @@ if (EXISTS ${CMAKE_SOURCE_DIR}/3rdparty/Catch2/extras/Catch.cmake)
     include(${CMAKE_SOURCE_DIR}/3rdparty/Catch2/extras/Catch.cmake)
 else()
     function(catch_discover_tests TARGET)
-    # Dummy macro to satisfy CMake until it fetches Catch2 repo.
     endfunction()
 endif()
 
@@ -12,15 +11,12 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/test)
 
 file(GLOB TEST_SRC CONFIGURE_DEPENDS *.cpp)
 
-# executable
 set(TARGET hft-market-making-tests)
 add_executable(${TARGET} ${TEST_SRC})
 
-# Link against the necessary libraries
 target_link_libraries(${TARGET} PRIVATE
     Catch2-static-lib
-    hft-market-making-common
+    hft-market-making-strategy
 )
 
-# Register the tests with CTest
 catch_discover_tests(${TARGET})

--- a/test/EngineFillsTest.cpp
+++ b/test/EngineFillsTest.cpp
@@ -1,0 +1,195 @@
+#include "engine/Engine.hpp"
+#include "engine/LatencyModel.hpp"
+
+#include "catch2/catch_all.hpp"
+
+using namespace cmf;
+
+namespace
+{
+
+struct RecordingStrategy : Strategy
+{
+    std::vector<ExecReport> fills;
+    std::vector<bool> makerFlags;
+
+    void on_l2(const L2Snapshot&, StrategyContext&) override {}
+    void on_trade(const TradeEvent&, StrategyContext&) override {}
+    void on_fill(const ExecReport& rep, Side, bool isMaker, StrategyContext&) override
+    {
+        fills.push_back(rep);
+        makerFlags.push_back(isMaker);
+    }
+};
+
+struct FeedL2 : IL2Reader
+{
+    std::vector<L2Snapshot> data;
+    std::size_t pos{0};
+    bool next(L2Snapshot& out) override
+    {
+        if (pos >= data.size())
+            return false;
+        out = data[pos++];
+        return true;
+    }
+};
+
+struct FeedTrades : ITradesReader
+{
+    std::vector<TradeEvent> data;
+    std::size_t pos{0};
+    bool next(TradeEvent& out) override
+    {
+        if (pos >= data.size())
+            return false;
+        out = data[pos++];
+        return true;
+    }
+};
+
+L2Snapshot make_l2(NanoTime ts, double bid, double bidQty, double ask, double askQty)
+{
+    L2Snapshot s;
+    s.ts = ts;
+    s.bids.push_back({bid, bidQty});
+    s.asks.push_back({ask, askQty});
+    return s;
+}
+
+} // namespace
+
+TEST_CASE("Limit order filled passively on trade - trade qty cap", "[Engine]")
+{
+    // Resting buy limit at 100 for qty=10. A sell trade hits at price 100, size 3.
+    // Fill should be capped at trade qty = 3, not order qty = 10.
+    struct LimitBuyStrategy : Strategy
+    {
+        ExecReport fill{};
+        bool filled{false};
+        bool placed{false};
+
+        void on_l2(const L2Snapshot& l2, StrategyContext& ctx) override
+        {
+            if (!placed)
+            {
+                Order o{0, OrderType::Limit, Side::Buy, 100.0, 10.0, l2.ts};
+                ctx.send_order(o);
+                placed = true;
+            }
+        }
+        void on_trade(const TradeEvent&, StrategyContext&) override {}
+        void on_fill(const ExecReport& rep, Side, bool, StrategyContext&) override
+        {
+            fill = rep;
+            filled = true;
+        }
+        ~LimitBuyStrategy() override = default;
+    };
+
+    auto strat = std::make_unique<LimitBuyStrategy>();
+    LimitBuyStrategy* stratPtr = strat.get();
+
+    BacktestEngine eng(std::make_unique<ConstLatency>(0), std::move(strat), Fees{0.0, 0.0});
+
+    auto l2Feed = std::make_unique<FeedL2>();
+    l2Feed->data.push_back(make_l2(1000, 99.0, 5.0, 101.0, 5.0));
+    l2Feed->data.push_back(make_l2(3000, 99.0, 5.0, 101.0, 5.0));
+
+    auto tradeFeed = std::make_unique<FeedTrades>();
+    tradeFeed->data.push_back({2000, Side::Sell, 100.0, 3.0});
+
+    eng.set_l2_reader(std::move(l2Feed));
+    eng.set_trades_reader(std::move(tradeFeed));
+    eng.run();
+
+    REQUIRE(stratPtr->filled);
+    REQUIRE(stratPtr->fill.filled == Catch::Approx(3.0));
+}
+
+TEST_CASE("Market order executes against best ask", "[Engine]")
+{
+    struct MarketBuyStrategy : Strategy
+    {
+        ExecReport fill{};
+        bool filled{false};
+        bool firstTick{true};
+
+        void on_l2(const L2Snapshot& l2, StrategyContext& ctx) override
+        {
+            if (firstTick)
+            {
+                Order o{0, OrderType::Market, Side::Buy, 0.0, 5.0, l2.ts};
+                ctx.send_order(o);
+                firstTick = false;
+            }
+        }
+        void on_trade(const TradeEvent&, StrategyContext&) override {}
+        void on_fill(const ExecReport& rep, Side, bool, StrategyContext&) override
+        {
+            fill = rep;
+            filled = true;
+        }
+        ~MarketBuyStrategy() override = default;
+    };
+
+    auto strat = std::make_unique<MarketBuyStrategy>();
+    MarketBuyStrategy* stratPtr = strat.get();
+
+    BacktestEngine eng(std::make_unique<ConstLatency>(0), std::move(strat), Fees{0.0, 0.0});
+
+    auto l2Feed = std::make_unique<FeedL2>();
+    l2Feed->data.push_back(make_l2(1000, 99.0, 10.0, 101.0, 10.0));
+    l2Feed->data.push_back(make_l2(2000, 99.0, 10.0, 101.0, 10.0));
+    eng.set_l2_reader(std::move(l2Feed));
+
+    eng.run();
+
+    REQUIRE(stratPtr->filled);
+    REQUIRE(stratPtr->fill.filled == Catch::Approx(5.0));
+    REQUIRE(stratPtr->fill.avgPrice == Catch::Approx(101.0));
+}
+
+TEST_CASE("Cancel prevents fill", "[Engine]")
+{
+    struct CancelStrategy : Strategy
+    {
+        bool cancelled{false};
+        bool filled{false};
+        ClOrdId orderId{0};
+
+        void on_l2(const L2Snapshot& l2, StrategyContext& ctx) override
+        {
+            if (orderId == 0)
+            {
+                Order o{0, OrderType::Limit, Side::Buy, 101.0, 5.0, l2.ts};
+                orderId = ctx.send_order(o);
+            }
+            else if (!cancelled)
+            {
+                ctx.cancel_order(orderId);
+                cancelled = true;
+            }
+        }
+        void on_trade(const TradeEvent&, StrategyContext&) override {}
+        void on_fill(const ExecReport&, Side, bool, StrategyContext&) override { filled = true; }
+        ~CancelStrategy() override = default;
+    };
+
+    auto strat = std::make_unique<CancelStrategy>();
+    CancelStrategy* stratPtr = strat.get();
+
+    // Zero latency: cancel at tick 2 should prevent fill at tick 3
+    BacktestEngine eng(std::make_unique<ConstLatency>(0), std::move(strat), Fees{0.0, 0.0});
+
+    auto l2Feed = std::make_unique<FeedL2>();
+    l2Feed->data.push_back(make_l2(1000, 99.0, 5.0, 102.0, 5.0));
+    l2Feed->data.push_back(make_l2(2000, 99.0, 5.0, 102.0, 5.0));
+    l2Feed->data.push_back(make_l2(3000, 100.5, 5.0, 101.0, 5.0));
+    eng.set_l2_reader(std::move(l2Feed));
+
+    eng.run();
+
+    REQUIRE(stratPtr->cancelled);
+    REQUIRE_FALSE(stratPtr->filled);
+}

--- a/test/MetricsTest.cpp
+++ b/test/MetricsTest.cpp
@@ -1,0 +1,93 @@
+#include "engine/Metrics.hpp"
+
+#include "catch2/catch_all.hpp"
+
+using namespace cmf;
+
+static std::vector<TradeRecord> make_trades(
+    const std::vector<std::tuple<NanoTime, Side, double, double, double>>& data)
+{
+    std::vector<TradeRecord> v;
+    for (const auto& [ts, side, qty, price, fee] : data)
+        v.push_back({ts, qty, price, side, fee});
+    return v;
+}
+
+TEST_CASE("Turnover sums price*qty", "[Metrics]")
+{
+    auto trades = make_trades({
+        {1, Side::Buy,  10.0, 100.0, 0.0},
+        {2, Side::Sell, 5.0,  102.0, 0.0},
+    });
+    Turnover t(trades);
+    REQUIRE(t.calculate() == Catch::Approx(10.0 * 100.0 + 5.0 * 102.0));
+}
+
+TEST_CASE("Turnover - empty returns 0", "[Metrics]")
+{
+    std::vector<TradeRecord> empty;
+    Turnover t(empty);
+    REQUIRE(t.calculate() == 0.0);
+}
+
+TEST_CASE("MaxAbsInventory - positive and negative", "[Metrics]")
+{
+    std::vector<double> inv = {0.0, 3.0, -5.0, 2.0, -1.0};
+    MaxAbsInventory m(inv);
+    REQUIRE(m.calculate() == Catch::Approx(5.0));
+}
+
+TEST_CASE("MaxAbsInventory - empty returns 0", "[Metrics]")
+{
+    std::vector<double> empty;
+    MaxAbsInventory m(empty);
+    REQUIRE(m.calculate() == 0.0);
+}
+
+TEST_CASE("TimeWeightedAvgInventory - uniform steps", "[Metrics]")
+{
+    std::vector<double> inv = {2.0, 4.0, 6.0};
+    std::vector<NanoTime> ts = {0, 1000, 2000};
+    TimeWeightedAvgInventory m(inv, ts);
+    // Two intervals: [0,1000) with inv=2.0, [1000,2000) with inv=4.0
+    // TWAP = (2.0*1000 + 4.0*1000) / 2000 = 3.0
+    REQUIRE(m.calculate() == Catch::Approx(3.0));
+}
+
+TEST_CASE("FillRatio - correct fraction", "[Metrics]")
+{
+    FillRatio f(10, 7);
+    REQUIRE(f.calculate() == Catch::Approx(0.7));
+}
+
+TEST_CASE("FillRatio - zero sent returns 0", "[Metrics]")
+{
+    FillRatio f(0, 0);
+    REQUIRE(f.calculate() == 0.0);
+}
+
+TEST_CASE("MaxDrawdownPct - simple drawdown", "[Metrics]")
+{
+    // Peak 100, then drops to 80 -> drawdown = (100-80)/100*100 = 20.0
+    std::vector<double> eq = {100.0, 90.0, 80.0, 95.0};
+    MaxDrawdownPct m(eq);
+    REQUIRE(m.calculate() == Catch::Approx(20.0).epsilon(0.01));
+}
+
+TEST_CASE("MaxDrawdownPct - no drawdown", "[Metrics]")
+{
+    std::vector<double> eq = {100.0, 110.0, 120.0};
+    MaxDrawdownPct m(eq);
+    REQUIRE(m.calculate() == Catch::Approx(0.0));
+}
+
+TEST_CASE("RealizedPnL - round-trip buy then sell", "[Metrics]")
+{
+    // Buy 1 unit at 100, sell 1 unit at 102 -> realized = +2 (minus fees)
+    auto trades = make_trades({
+        {1, Side::Buy,  1.0, 100.0, 0.0},
+        {2, Side::Sell, 1.0, 102.0, 0.0},
+    });
+    RealizedPnL p(trades);
+    REQUIRE(p.calculate() == Catch::Approx(2.0));
+}

--- a/test/MicropriceTest.cpp
+++ b/test/MicropriceTest.cpp
@@ -1,0 +1,59 @@
+#include "strategy/Microprice.hpp"
+
+#include "catch2/catch_all.hpp"
+
+using namespace cmf;
+
+static L2Snapshot make_book(double bidPx, double bidQty, double askPx, double askQty)
+{
+    L2Snapshot s;
+    s.bids.push_back({bidPx, bidQty});
+    s.asks.push_back({askPx, askQty});
+    return s;
+}
+
+TEST_CASE("mid - balanced book", "[Microprice]")
+{
+    auto s = make_book(100.0, 10.0, 102.0, 10.0);
+    REQUIRE(mid(s) == Catch::Approx(101.0));
+}
+
+TEST_CASE("mid - empty book returns 0", "[Microprice]")
+{
+    L2Snapshot s;
+    REQUIRE(mid(s) == 0.0);
+}
+
+TEST_CASE("microprice - balanced book equals mid", "[Microprice]")
+{
+    auto s = make_book(100.0, 5.0, 102.0, 5.0);
+    REQUIRE(microprice(s) == Catch::Approx(mid(s)));
+}
+
+TEST_CASE("microprice - heavy bid side pushes toward ask", "[Microprice]")
+{
+    auto s = make_book(100.0, 9.0, 102.0, 1.0);
+    const double mp = microprice(s);
+    REQUIRE(mp > mid(s));
+    REQUIRE(mp < 102.0);
+}
+
+TEST_CASE("microprice - heavy ask side pushes toward bid", "[Microprice]")
+{
+    auto s = make_book(100.0, 1.0, 102.0, 9.0);
+    const double mp = microprice(s);
+    REQUIRE(mp < mid(s));
+    REQUIRE(mp > 100.0);
+}
+
+TEST_CASE("microprice - empty book returns 0", "[Microprice]")
+{
+    L2Snapshot s;
+    REQUIRE(microprice(s) == 0.0);
+}
+
+TEST_CASE("microprice - zero total qty falls back to mid", "[Microprice]")
+{
+    auto s = make_book(100.0, 0.0, 102.0, 0.0);
+    REQUIRE(microprice(s) == Catch::Approx(101.0));
+}

--- a/test/VolatilityTest.cpp
+++ b/test/VolatilityTest.cpp
@@ -1,0 +1,72 @@
+#include "strategy/Volatility.hpp"
+
+#include "catch2/catch_all.hpp"
+
+#include <cmath>
+
+using namespace cmf;
+
+TEST_CASE("EwmaVariance - not initialized after 1 price", "[Volatility]")
+{
+    EwmaVariance ev(100.0);
+    ev.update(1.0);
+    REQUIRE_FALSE(ev.initialized());
+}
+
+TEST_CASE("EwmaVariance - initialized after 3 prices", "[Volatility]")
+{
+    // First call sets prevLogPx, second produces 1 return (n=1), third produces n=2 -> initialized
+    EwmaVariance ev(100.0);
+    ev.update(1.0);
+    REQUIRE_FALSE(ev.initialized());
+    ev.update(1.01);
+    REQUIRE_FALSE(ev.initialized()); // n=1, needs n>=2
+    ev.update(1.02);
+    REQUIRE(ev.initialized()); // n=2
+}
+
+TEST_CASE("EwmaVariance - zero variance for flat prices", "[Volatility]")
+{
+    EwmaVariance ev(100.0);
+    for (int i = 0; i < 200; ++i)
+        ev.update(100.0);
+    REQUIRE(ev.value() == Catch::Approx(0.0).margin(1e-12));
+}
+
+TEST_CASE("EwmaVariance - converges to known variance", "[Volatility]")
+{
+    // Feed alternating returns of +r, -r. True per-step variance = r^2.
+    const double r = 0.001;
+    const double halfLife = 50.0;
+    EwmaVariance ev(halfLife);
+    double px = 1.0;
+    for (int i = 0; i < 2000; ++i)
+    {
+        px *= (i % 2 == 0) ? (1.0 + r) : (1.0 / (1.0 + r));
+        ev.update(px);
+    }
+    const double logR = std::log(1.0 + r);
+    REQUIRE(ev.value() == Catch::Approx(logR * logR).epsilon(0.15));
+}
+
+TEST_CASE("EwmaVariance - respects cap", "[Volatility]")
+{
+    const double cap = 1e-4;
+    EwmaVariance ev(100.0, cap);
+    ev.update(1.0);
+    ev.update(1000.0); // huge jump
+    REQUIRE(ev.value() <= cap + 1e-15);
+}
+
+TEST_CASE("EwmaVariance - ignores non-positive prices", "[Volatility]")
+{
+    EwmaVariance ev(100.0);
+    ev.update(1.0);      // sets prevLogPx, n=0
+    ev.update(0.0);      // skipped
+    ev.update(-1.0);     // skipped
+    REQUIRE_FALSE(ev.initialized()); // still n=0
+    ev.update(1.01);     // n=1
+    REQUIRE_FALSE(ev.initialized()); // n=1 < 2
+    ev.update(1.02);     // n=2
+    REQUIRE(ev.initialized());
+}


### PR DESCRIPTION
Implements a full C++20 backtesting engine for limit order book simulation with the Avellaneda-Stoikov (2008) market-making strategy and Stoikov (2018) microprice enhancement.

## Engine

Event-driven backtest loop with priority queue, limit/market order placement and cancellation, passive/aggressor fill classification, configurable latency model (constant or lognormal), maker/taker fee accounting, equity and inventory time series.

## Strategy

Reservation price $r_t = s_t - q_t \gamma \sigma_t^2 (T-t)$, optimal half-spread $\delta_t^* = \frac{\gamma \sigma_t^2 (T-t)}{2} + \frac{1}{\gamma} \ln\left(1 + \frac{\gamma}{k}\right)$, EWMA variance estimator with configurable half-life, log-linear OLS intensity fit for $k$ from trade data, switchable reference price (mid vs microprice), inventory cap.

## Results

On 6-day crypto dataset (~1M L2 rows, ~22M trades): both variants generate ~1.2M fills; PnL negative due to 29.5% directional crash during the session — strategy mean-reverts inventory correctly but cannot hedge a persistent trend. Microprice variant performs similarly to mid in this regime.

## Tests

32 Catch2 tests covering microprice math, EWMA convergence, A-S quote properties ($\delta_t^* > 0$, $\text{sign}(r_t - s_t) = -\text{sign}(q_t)$, $\delta_t^*$ independent of $q_t$), metrics correctness, and engine fill semantics.
