### PR TITLE
Python HFT Market-Making Backtester Submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,9 @@ The current pre-commit hooks do the following:
 - format and lint C++ code with `clang-format`;
 - format and lint Python code with `ruff`;
 - strip outputs from Jupyter notebooks.
+
+# Python Implementation
+
+The complete Python implementation for the HFT market-making backtester is available here:
+
+https://github.com/a12xsktl/hft-backtester


### PR DESCRIPTION
# HFT Market-Making Backtester Submission

This submission contains a Python implementation of an inventory-aware HFT market-making framework.

Implemented components:

* replay-based backtesting engine,
* limit order placement and cancellation,
* execution based on market price crossing,
* inventory and cash accounting,
* baseline market making strategy,
* Avellaneda–Stoikov market making,
* enhanced alpha-driven quoting,
* parameter sweep experiments.

The project includes:

* order book feature engineering,
* trade-flow feature engineering,
* causal alpha signal construction,
* inventory-aware quoting logic,
* simulation experiments and analysis.

The full Python implementation is available here:

https://github.com/a12xsktl/hft-backtester

The repository contains:

* Jupyter notebook with the implementation,
* project report,

